### PR TITLE
Helper to tokenize strings

### DIFF
--- a/src/helpers/tokenize.test.ts
+++ b/src/helpers/tokenize.test.ts
@@ -1,0 +1,19 @@
+import tokenize from "./tokenize";
+
+describe("Tokenize", () => {
+  it("returns 3 tokens", () => {
+    expect(tokenize("a ber cd")).toStrictEqual(["a", "ber", "cd"]);
+  });
+
+  it("returns 1 tokens", () => {
+    expect(tokenize(" 1")).toStrictEqual(["1"]);
+  });
+
+  it("returns 0 tokens", () => {
+    expect(tokenize(" ")).toStrictEqual(null);
+  });
+
+  it("returns tokens with non-alpanumeric chars", () => {
+    expect(tokenize("ab ;12")).toStrictEqual(["ab", ";12"]);
+  });
+});

--- a/src/helpers/tokenize.ts
+++ b/src/helpers/tokenize.ts
@@ -1,0 +1,8 @@
+/*
+ * tokenize returns array
+ * of tokens broken by any non-whitespace char in str
+ * empty str returns null
+ */
+export default function tokenize(str: string) {
+  return str.match(/\S+/g);
+}


### PR DESCRIPTION
- Required for when we send user command to OS
- OS requires input to be tokenized.